### PR TITLE
Update find_package line for the python interpreter

### DIFF
--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -8,7 +8,8 @@ find_package(SWIG REQUIRED)
 include(${SWIG_USE_FILE})
 
 # SWIG requires the Python header
-find_package(Python COMPONENTS Development REQUIRED)
+# find_package(Python COMPONENTS Development REQUIRED) # worked for python<=3.10 but not for 3.11,3.12
+find_package(Python COMPONENTS Interpreter Development)
 include_directories(${PYTHON_INCLUDE_PATH})
 # TODO: Is NumPy required?
 #find_package(NumPy REQUIRED)


### PR DESCRIPTION
The old line syntax works only for python<=3.10.